### PR TITLE
Extending ...

### DIFF
--- a/views/templates/hook/hookDisplayCustomerAccountForm.tpl
+++ b/views/templates/hook/hookDisplayCustomerAccountForm.tpl
@@ -32,7 +32,7 @@
  * Le contenu du captcha est automatiquement ajouté dans le selecteur #captcha-box
  * Captcha content is automaticaly added into the selector #captcha-box
  *}
-<div class="g-recaptcha{if $prestashopVersion|escape:'html' == 16 } row {/if}" data-sitekey="{$publicKey|escape:'html'}" id="captcha-box"></div>
+<div class="g-recaptcha{if $prestashopVersion|escape:'html' == 16 } row {/if}" data-sitekey="{$publicKey|escape:'html'}" id="captcha-box" data-theme="{$captchatheme}"></div>
 
 {if $prestashopVersion|escape:'html' == 15 }
 	</fieldset>	
@@ -45,4 +45,4 @@
  errorSelector = '{$errorSelector|escape:'html'}';
  formSelector = '{$formSelector|escape:'html'}';
 </script>
-<script src="https://www.google.com/recaptcha/api.js" async defer></script>
+<script src="https://www.google.com/recaptcha/api.js?hl={$captchaforcelang}" async defer></script>


### PR DESCRIPTION
Hi,
First of all, thank You for your work.

Added few lines code, to extend capabilities, if You find it useful/OK, please apply them.

--
Thanks,
Olivér

The original comment of me:
### Added options for two recaptcha setting
1) force language via code - reason sometimes the autodetection of google recaptcha doesn't work correctly
2) select light or dark theme for display recaptcha

(Only the core tested (account-creation, contact), not the modules!)