### PR TITLE
Added displayNewsletterRegsitration hook to installation method

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -36,6 +36,7 @@ class Installer
     protected $_hooks = [
         'displayHeader',
         'displayCustomerAccountForm',
+        'displayNewsletterRegistration',
         'actionContactFormSubmitCaptcha',
         'actionContactFormSubmitBefore',
         'actionNewsletterRegistrationBefore',


### PR DESCRIPTION
Hello Hervé,

I had trouble with newsletter registration form because eicaptcha does not register itself on displayNewsletterRegistration hook. Just made the small modification on local, uploaded on my Prestashop and finally get recaptcha stuff on the form :)