### PR TITLE
Add 2 missing hooks on installation

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -42,6 +42,7 @@ class Installer
         'actionNewsletterRegistrationBefore',
         'actionAdminControllerSetMedia',
         'actionContactFormSubmitCaptcha',
+        'displayEicaptchaVerification',
     ];
 
     /**

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -41,6 +41,7 @@ class Installer
         'actionContactFormSubmitBefore',
         'actionNewsletterRegistrationBefore',
         'actionAdminControllerSetMedia',
+        'actionContactFormSubmitCaptcha',
     ];
 
     /**


### PR DESCRIPTION
Hello @nenes25
I've an issue on this module when i want to submit the contact form, i've look up an it came from the hook: `displayEicaptchaVerification` is missing in the installation `Tools::getValue('g-recaptcha-response')` is null. 

And i've put the hook  : `{hook h='displayEicaptchaVerification'}` in my template file: `contactform/views/templates/widget/contactform.tpl`

I've also add the `actionContactFormSubmitCaptcha` because it displayed an error at the check settings tab. 

Thanks for you module