### PR TITLE
Fix light/dark theme selection (recaptcha v2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ vendor
 .github/config.php
 .github/eicaptcha.zip
 .github/build.sh
+.idea
 config.xml
 config_*.xml
 logs/*.log

--- a/src/ConfigForm.php
+++ b/src/ConfigForm.php
@@ -210,12 +210,12 @@ class ConfigForm
                         'values' => [
                             [
                                 'id' => 'cdark',
-                                'value' => 0,
+                                'value' => 1,
                                 'label' => $this->l('Dark'),
                             ],
                             [
                                 'id' => 'clight',
-                                'value' => 1,
+                                'value' => 0,
                                 'label' => $this->l('Light'),
                             ],
                         ],


### PR DESCRIPTION
In the configuration form the values for the Light and Dark setting are inverted, and is misleading during the configuration of the module.

Before the PR when you select Dark it sets the Light and viceversa.
This PR fix the issue 😊 

--- 

PS: I've update also the .gitignore adding the .idea folder that phpstorm creates